### PR TITLE
Feature/remove iris links from show

### DIFF
--- a/app/views/catalog/_upper_metadata.html.erb
+++ b/app/views/catalog/_upper_metadata.html.erb
@@ -1,0 +1,16 @@
+<% document ||= @document %>
+<% doc_presenter = show_presenter(document) %>
+<div class="geoblacklight-view-panel">
+
+  <%# From https://github.com/projectblacklight/blacklight/blob/master/app/views/catalog/_show_default.html.erb %>
+  <%# default partial to display solr document fields in catalog show view -%>
+  <dl class="dl-horizontal">
+    <%# render 'abstract_metadata' %>
+    <% document_show_fields(document).each do |solr_fname, field| %>
+      <% if should_render_show_field? document, field %>
+        <dt class="blacklight-<%= solr_fname.parameterize %>"><%= render_document_show_field_label document, field: solr_fname %></dt>
+        <dd class="blacklight-<%= solr_fname.parameterize %>"><%= doc_presenter.field_value solr_fname %></dd>
+      <% end %>
+    <% end %>
+  </dl>
+</div>

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -9,4 +9,8 @@ RSpec.describe 'viewing content on the aster show page', type: :feature do
     visit solr_document_path 'gford-20140000-010015_belvegr'
     expect(page).to have_content 'Vegetation, Maya Forest, Belize, 1995'
   end
+  scenario 'viewing the show page and not seeing links back to Geoworks/Hyrax/Iris' do
+    visit solr_document_path 'gford-20140000-010015_belvegr'
+    expect(page).not_to have_link 'http://iris-demo.curationexperts.com/concern/vector_works/7d278t00k'
+  end
 end

--- a/spec/fixtures/solr_documents/maya_forest.json
+++ b/spec/fixtures/solr_documents/maya_forest.json
@@ -8,7 +8,7 @@
     "dc_rights_s": "Public",
     "dc_title_s": "Vegetation, Maya Forest, Belize, 1995",
     "dc_type_s": "Dataset",
-    "dct_references_s": "{\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"http://geoservices-sandbox.library.ucsb.edu:8080/geoserver/ucsb/ows?service=WFS\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"http://geoservices-sandbox.library.ucsb.edu:8080/geoserver/ucsb/wms?service=WMS\"}",
+    "dct_references_s": "{\"http://schema.org/url\":\"http://iris-demo.curationexperts.com/concern/vector_works/7d278t00k\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"http://geoservices-sandbox.library.ucsb.edu:8080/geoserver/ucsb/ows?service=WFS\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"http://geoservices-sandbox.library.ucsb.edu:8080/geoserver/ucsb/wms?service=WMS\"}",
     "solr_geom": "ENVELOPE(-88.0804, -89.2587, 18.4977, 15.8808)",
     "dct_spatial_sm": "Belize",
     "dc_subject_sm":"Belize",


### PR DESCRIPTION
These commits remove a link that appears in the
show page that links you back to the show page in
Iris.

Closes curationexperts/alexandria#89