### PR TITLE
Feature/file download

### DIFF
--- a/spec/features/download_zip_button_spec.rb
+++ b/spec/features/download_zip_button_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'downloading the shapefile as a zip', type: :feature do
+  let(:download_path) { '/download/gford-20140000-010015_belvegr?type=shapefile' }
+  let(:page_markup) { page.html.to_s }
+  before do
+    Rake::Task['geoblacklight:solr:seed'].invoke
+  end
+  scenario 'viewing the download button on the show page' do
+    visit solr_document_path 'gford-20140000-010015_belvegr'
+    expect(page).to have_content('Download Shapefile')
+    expect(page_markup.include?(download_path)).to eq(true)
+  end
+end

--- a/spec/fixtures/solr_documents/maya_forest.json
+++ b/spec/fixtures/solr_documents/maya_forest.json
@@ -14,6 +14,7 @@
     "dc_subject_sm":"Belize",
     "dc_creator_sm":"UCSB",
     "dct_provenance_s": "UCSB",
-    "layer_geom_type_s": "Polygon"
+    "layer_geom_type_s": "Mixed",
+    "dc_format_s":"Shapefile"
   }
 ]


### PR DESCRIPTION
This modifies the solr document fixture so that a download
button is displayed on the show page. There is a feature
test that ensures that the correct URL and the button
are on the page.

Closes curationexperts/aster#19